### PR TITLE
Weather: remove WeatherStation

### DIFF
--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -16,13 +16,12 @@ func main() {
 		APIKey("YOUR_API_KEY").
 		Query(
 			trafikinfo.NewQuery(
-				trafikinfo.WeatherStation,
-				1.0,
+				trafikinfo.WeatherMeasurePoint,
+				2.0,
 			).Filter(
-				trafikinfo.Equal("Id", "YOUR_STATION_ID"),
+				trafikinfo.Equal("Name", "YOUR_STATION_NAME"),
 			),
 		).Build()
-
 	if err != nil {
 		panic(err)
 	}
@@ -45,10 +44,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+
 	if resp.StatusCode == http.StatusBadRequest {
 		var e trafikinfo.APIError
-		d := json.NewDecoder(resp.Body)
-		err := d.Decode(&e)
+		err := json.Unmarshal(data, &e)
 		if err != nil {
 			fmt.Println("Could not decode API error response")
 			os.Exit(1)
@@ -66,15 +69,16 @@ func main() {
 	type respMsg struct {
 		Resonpse struct {
 			Result []struct {
-				WeatherStation []trafikinfo.WeatherStation1Dot0 `json:"WeatherStation"`
-				Info           trafikinfo.Info                  `json:"INFO"`
+				MeasurePoint []trafikinfo.WeatherMeasurepoint2Dot0 `json:"WeatherMeasurepoint"`
+				Info         trafikinfo.Info                       `json:"INFO"`
 			}
 		} `json:"RESPONSE"`
 	}
 
+	fmt.Println(string(data))
+
 	var c respMsg
-	d := json.NewDecoder(resp.Body)
-	err = d.Decode(&c)
+	err = json.Unmarshal(data, &c)
 	if err != nil {
 		panic(err)
 	}

--- a/weather.go
+++ b/weather.go
@@ -2,110 +2,6 @@ package trafikinfo
 
 import "time"
 
-// WeatherStation1Dot0 is the WeatherStation v1.0 model. It returns all kinds
-// of environmental data
-type WeatherStation1Dot0 struct {
-	// Active indicates this station is returning data
-	Active *bool `json:"Active,omitempty"`
-	// County is the Swedish county in which this station is located
-	County []County `json:"CountyNo,omitempty"`
-	// Deleted indicates if this is a deleted object. This should only
-	// ever be true if you created a Query with IncludeDeletedItems
-	Deleted *bool `json:"Deleted,omitempty"`
-	// Geometry contains coordinates for where this station is located
-	Geometry *Geometry `json:"Geometry,omitempty"`
-	// IconID is an identifier that can be used with a query for the Icon
-	// object type to retrieve the base64 encoded PNG and the URL at which
-	// the icon can also be retrieved
-	IconID *string `json:"IconId,omitempty"`
-	// ID is the unique ID identifying this station
-	ID *string `json:"Id,omitempty"`
-	// Measurement represents measurement data from environmental sensors
-	Measurement *struct {
-		// Air contains the typical things like relative humidity and temperature
-		// as measured in the air
-		Air *struct {
-			// RelativeHumidity is the relative humidity in percent
-			RelativeHumidity *float64 `json:"RelativeHumidity,omitempty"`
-			// Temperature is measured in degrees Celsius
-			Temperature       *float64 `json:"Temp,omitempty"`
-			TemperatureIconID *string  `json:"TempIconId,omitempty"`
-		} `json:"Air,omitempty"`
-		// MeasurTime indicates when these values where recorded
-		MeasureTime *time.Time `json:"MeasureTime,omitempty"`
-		// Precipitation contains the type and amount of precipitation
-		Precipitation *struct {
-			// Amount is the mount of rain in mm per hour. It's worth noting
-			// that in practice it turns out the absence of a value indicates
-			// "no rain", i.e precipitation of 0, not "this station doesn't
-			// report precipitation", unless Measurement was Excluded by the
-			// Query
-			Amount *float64 `json:"Amount,omitempty"`
-			// AmountName is a predefined string describing the type and amount
-			// of precipitation in Swedish
-			AmountName *PrecipitationAmount `json:"AmountName,omitempty"`
-			// Type is a predefined string describing the type of precipitation
-			// in Swedish
-			Type       *PrecipitationType `json:"Type,omitempty"`
-			TypeIconID *string            `json:"TypeIconId,omitempty"`
-		} `json:"Precipitation,omitempty"`
-		// Road contains the temperature as measured at the road deck level.
-		// This can be much higher or lower than the Air values
-		Road *struct {
-			// Temperature is measured in degrees Celsius
-			Temperature       *float64 `json:"Temp,omitempty"`
-			TemperatureIconID *string  `json:"TempIconId,omitempty"`
-		} `json:"Road,omitempty"`
-		// Wind contains wind direction and strength
-		Wind *struct {
-			// Direction is represented in degrees
-			Direction       *float64 `json:"Direction,omitempty"`
-			DirectionIconID *string  `json:"DirectionIconId,omitempty"`
-			// DirectionText is a predefined string representing the wind
-			// direction in Swedish
-			DirectionText *WindDirection `json:"DirectionText,omitempty"`
-			// Force is the 10 minute average in m/sec
-			Force *float64 `json:"Force,omitempty"`
-			// ForceMax is the 30 minute max in m/sec
-			ForceMax *float64 `json:"ForceMax,omitempty"`
-		} `json:"Wind,omitempty"`
-	} `json:"Measurement,omitempty"`
-	// MeasurementHistory contains multiple instances of Measurement
-	// over time. See the comments on Measurement for how to interpret
-	// the data
-	MeasurementHistory []struct {
-		Air *struct {
-			RelativeHumidity  *float64 `json:"RelativeHumidity,omitempty"`
-			Temperature       *float64 `json:"Temp,omitempty"`
-			TemperatureIconID *string  `json:"TempIconId,omitempty"`
-		} `json:"Air,omitempty"`
-		MeasureTime   *time.Time `json:"MeasureTime,omitempty"`
-		Precipitation *struct {
-			Amount     *float64             `json:"Amount,omitempty"`
-			AmountName *PrecipitationAmount `json:"AmountName,omitempty"`
-			Type       *PrecipitationType   `json:"Type,omitempty"`
-			TypeIconID *string              `json:"TypeIconId,omitempty"`
-		} `json:"Precipitation,omitempty"`
-		Road *struct {
-			Temperature       *float64 `json:"Temp,omitempty"`
-			TemperatureIconID *string  `json:"TempIconId,omitempty"`
-		} `json:"Road,omitempty"`
-		Wind *struct {
-			Direction       *float64       `json:"Direction,omitempty"`
-			DirectionIconID *string        `json:"DirectionIconId,omitempty"`
-			DirectionText   *WindDirection `json:"DirectionText,omitempty"`
-			Force           *float64       `json:"Force,omitempty"`
-			ForceMax        *float64       `json:"ForceMax,omitempty"`
-		} `json:"Wind,omitempty"`
-	} `json:"MeasurementHistory,omitempty"`
-	// ModifiedTime represents when this object was last modified
-	ModifiedTime *time.Time `json:"ModifiedTime,omitempty"`
-	// Name is the name of the station
-	Name *string `json:"Name,omitempty"`
-	// RoadNumber is the Swedish road number this station is located at
-	RoadNumber *int `json:"RoadNumberNumeric,omitempty"`
-}
-
 type PrecipitationAmount string
 
 const (
@@ -164,22 +60,22 @@ type WeatherObservation1Dot0 struct {
 		Precipitation *struct {
 			Rain    *bool `json:"Rain,omitempty"`
 			RainSum *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"RainSum"`
 			Snow    *bool `json:"Snow,omitempty"`
 			SnowSum *struct {
 				Solid *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"Solid,omitempty"`
 			} `json:"SnowSum,omitempty"`
 			TotalWaterEquivalent *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"TotalWaterEquivalent,omitempty"`
 		} `json:"Precipitation,omitempty"`
 		Wind *struct {
@@ -200,22 +96,22 @@ type WeatherObservation1Dot0 struct {
 		Precipitation *struct {
 			Rain    *bool `json:"Rain,omitempty"`
 			RainSum *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"RainSum"`
 			Snow    *bool `json:"Snow,omitempty"`
 			SnowSum *struct {
 				Solid *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"Solid,omitempty"`
 			} `json:"SnowSum,omitempty"`
 			TotalWaterEquivalent *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"TotalWaterEquivalent,omitempty"`
 		} `json:"Precipitation,omitempty"`
 		Wind *struct {
@@ -236,22 +132,22 @@ type WeatherObservation1Dot0 struct {
 		Precipitation *struct {
 			Rain    *bool `json:"Rain,omitempty"`
 			RainSum *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"RainSum"`
 			Snow    *bool `json:"Snow,omitempty"`
 			SnowSum *struct {
 				Solid *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"Solid,omitempty"`
 			} `json:"SnowSum,omitempty"`
 			TotalWaterEquivalent *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"TotalWaterEquivalent,omitempty"`
 		} `json:"Precipitation,omitempty"`
 		Wind *struct {
@@ -397,22 +293,22 @@ type WeatherObservation2Dot0 struct {
 		Precipitation *struct {
 			Rain    *bool `json:"Rain,omitempty"`
 			RainSum *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"RainSum"`
 			Snow    *bool `json:"Snow,omitempty"`
 			SnowSum *struct {
 				Solid *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"Solid,omitempty"`
 			} `json:"SnowSum,omitempty"`
 			TotalWaterEquivalent *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"TotalWaterEquivalent,omitempty"`
 		} `json:"Precipitation,omitempty"`
 		Wind *struct {
@@ -433,22 +329,22 @@ type WeatherObservation2Dot0 struct {
 		Precipitation *struct {
 			Rain    *bool `json:"Rain,omitempty"`
 			RainSum *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"RainSum"`
 			Snow    *bool `json:"Snow,omitempty"`
 			SnowSum *struct {
 				Solid *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"Solid,omitempty"`
 			} `json:"SnowSum,omitempty"`
 			TotalWaterEquivalent *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"TotalWaterEquivalent,omitempty"`
 		} `json:"Precipitation,omitempty"`
 		Wind *struct {
@@ -469,22 +365,22 @@ type WeatherObservation2Dot0 struct {
 		Precipitation *struct {
 			Rain    *bool `json:"Rain,omitempty"`
 			RainSum *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"RainSum"`
 			Snow    *bool `json:"Snow,omitempty"`
 			SnowSum *struct {
 				Solid *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"Solid,omitempty"`
 			} `json:"SnowSum,omitempty"`
 			TotalWaterEquivalent *struct {
-				Origin      *Origin `json:"Origin,omitempty"`
-				SensorNames *string `json:"SensorNames,omitempty"`
-				Value       *int    `json:"Value,omitempty"`
+				Origin      *Origin  `json:"Origin,omitempty"`
+				SensorNames *string  `json:"SensorNames,omitempty"`
+				Value       *float64 `json:"Value,omitempty"`
 			} `json:"TotalWaterEquivalent,omitempty"`
 		} `json:"Precipitation,omitempty"`
 		Wind *struct {
@@ -619,22 +515,22 @@ type WeatherMeasurepoint1Dot0 struct {
 			Precipitation *struct {
 				Rain    *bool `json:"Rain,omitempty"`
 				RainSum *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"RainSum"`
 				Snow    *bool `json:"Snow,omitempty"`
 				SnowSum *struct {
 					Solid *struct {
-						Origin      *Origin `json:"Origin,omitempty"`
-						SensorNames *string `json:"SensorNames,omitempty"`
-						Value       *int    `json:"Value,omitempty"`
+						Origin      *Origin  `json:"Origin,omitempty"`
+						SensorNames *string  `json:"SensorNames,omitempty"`
+						Value       *float64 `json:"Value,omitempty"`
 					} `json:"Solid,omitempty"`
 				} `json:"SnowSum,omitempty"`
 				TotalWaterEquivalent *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"TotalWaterEquivalent,omitempty"`
 			} `json:"Precipitation,omitempty"`
 			Wind *struct {
@@ -655,22 +551,22 @@ type WeatherMeasurepoint1Dot0 struct {
 			Precipitation *struct {
 				Rain    *bool `json:"Rain,omitempty"`
 				RainSum *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"RainSum"`
 				Snow    *bool `json:"Snow,omitempty"`
 				SnowSum *struct {
 					Solid *struct {
-						Origin      *Origin `json:"Origin,omitempty"`
-						SensorNames *string `json:"SensorNames,omitempty"`
-						Value       *int    `json:"Value,omitempty"`
+						Origin      *Origin  `json:"Origin,omitempty"`
+						SensorNames *string  `json:"SensorNames,omitempty"`
+						Value       *float64 `json:"Value,omitempty"`
 					} `json:"Solid,omitempty"`
 				} `json:"SnowSum,omitempty"`
 				TotalWaterEquivalent *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"TotalWaterEquivalent,omitempty"`
 			} `json:"Precipitation,omitempty"`
 			Wind *struct {
@@ -691,22 +587,22 @@ type WeatherMeasurepoint1Dot0 struct {
 			Precipitation *struct {
 				Rain    *bool `json:"Rain,omitempty"`
 				RainSum *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"RainSum"`
 				Snow    *bool `json:"Snow,omitempty"`
 				SnowSum *struct {
 					Solid *struct {
-						Origin      *Origin `json:"Origin,omitempty"`
-						SensorNames *string `json:"SensorNames,omitempty"`
-						Value       *int    `json:"Value,omitempty"`
+						Origin      *Origin  `json:"Origin,omitempty"`
+						SensorNames *string  `json:"SensorNames,omitempty"`
+						Value       *float64 `json:"Value,omitempty"`
 					} `json:"Solid,omitempty"`
 				} `json:"SnowSum,omitempty"`
 				TotalWaterEquivalent *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"TotalWaterEquivalent,omitempty"`
 			} `json:"Precipitation,omitempty"`
 			Wind *struct {
@@ -825,22 +721,22 @@ type WeatherMeasurepoint2Dot0 struct {
 			Precipitation *struct {
 				Rain    *bool `json:"Rain,omitempty"`
 				RainSum *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"RainSum"`
 				Snow    *bool `json:"Snow,omitempty"`
 				SnowSum *struct {
 					Solid *struct {
-						Origin      *Origin `json:"Origin,omitempty"`
-						SensorNames *string `json:"SensorNames,omitempty"`
-						Value       *int    `json:"Value,omitempty"`
+						Origin      *Origin  `json:"Origin,omitempty"`
+						SensorNames *string  `json:"SensorNames,omitempty"`
+						Value       *float64 `json:"Value,omitempty"`
 					} `json:"Solid,omitempty"`
 				} `json:"SnowSum,omitempty"`
 				TotalWaterEquivalent *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"TotalWaterEquivalent,omitempty"`
 			} `json:"Precipitation,omitempty"`
 			Wind *struct {
@@ -861,22 +757,22 @@ type WeatherMeasurepoint2Dot0 struct {
 			Precipitation *struct {
 				Rain    *bool `json:"Rain,omitempty"`
 				RainSum *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"RainSum"`
 				Snow    *bool `json:"Snow,omitempty"`
 				SnowSum *struct {
 					Solid *struct {
-						Origin      *Origin `json:"Origin,omitempty"`
-						SensorNames *string `json:"SensorNames,omitempty"`
-						Value       *int    `json:"Value,omitempty"`
+						Origin      *Origin  `json:"Origin,omitempty"`
+						SensorNames *string  `json:"SensorNames,omitempty"`
+						Value       *float64 `json:"Value,omitempty"`
 					} `json:"Solid,omitempty"`
 				} `json:"SnowSum,omitempty"`
 				TotalWaterEquivalent *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"TotalWaterEquivalent,omitempty"`
 			} `json:"Precipitation,omitempty"`
 			Wind *struct {
@@ -897,22 +793,22 @@ type WeatherMeasurepoint2Dot0 struct {
 			Precipitation *struct {
 				Rain    *bool `json:"Rain,omitempty"`
 				RainSum *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"RainSum"`
 				Snow    *bool `json:"Snow,omitempty"`
 				SnowSum *struct {
 					Solid *struct {
-						Origin      *Origin `json:"Origin,omitempty"`
-						SensorNames *string `json:"SensorNames,omitempty"`
-						Value       *int    `json:"Value,omitempty"`
+						Origin      *Origin  `json:"Origin,omitempty"`
+						SensorNames *string  `json:"SensorNames,omitempty"`
+						Value       *float64 `json:"Value,omitempty"`
 					} `json:"Solid,omitempty"`
 				} `json:"SnowSum,omitempty"`
 				TotalWaterEquivalent *struct {
-					Origin      *Origin `json:"Origin,omitempty"`
-					SensorNames *string `json:"SensorNames,omitempty"`
-					Value       *int    `json:"Value,omitempty"`
+					Origin      *Origin  `json:"Origin,omitempty"`
+					SensorNames *string  `json:"SensorNames,omitempty"`
+					Value       *float64 `json:"Value,omitempty"`
 				} `json:"TotalWaterEquivalent,omitempty"`
 			} `json:"Precipitation,omitempty"`
 			Wind *struct {


### PR DESCRIPTION
Trafikverket has indicated the `WeatherStation` will be removed from their API on the 30th of January 2024. This removes the type and updates the example to use `WeatherMeasurepoint` instead.

Some of the `.Value` fields in the XML are tagged as `decimal`, but were incorrectly translated to int in Go. Though `float64` isn't quite the equivalent for `decimal`, it's good enough for our uses here.